### PR TITLE
Allow different ActorJobs to run in parallel

### DIFF
--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/ActorJob.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/ActorJob.scala
@@ -24,7 +24,8 @@ class ActorJob(jobType: JobType,
 
   override def run()(implicit ctxt: JobContext): JobExecution = new JobExecution() {
 
-    private val actor = system.actorOf(props(ctxt), s"${jobType.name}-${ctxt.jobId}")
+    private val actorName = s"${jobType.name}-${ctxt.jobId}"
+    private val actor = system.actorOf(props(ctxt), actorName)
     private val promise = Promise[Unit]()
     override val result: Future[Unit] = promise.future
 
@@ -36,7 +37,7 @@ class ActorJob(jobType: JobType,
           promise.success(())
           context.stop(self)
       }
-    }), "ActorJobWatcher")
+    }), s"${actorName}_watcher")
 
     override def cancel(): Unit = actor ! ActorJob.Cancel
 


### PR DESCRIPTION
Because the ActorJob created a watcher Actor with a fixed name,
running multiple ActorJobs in parallel lead to an error when the second
ActorJob was run:

```
akka.actor.InvalidActorNameException: actor name [ActorJobWatcher] is not unique!
```

To fix this the name for the watcher actor is based on the
child actor's name.
