### PR TITLE
fix some c* issues: job status meta data and locks should not be selected by 'SELECT *'

### DIFF
--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatus.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatus.scala
@@ -68,16 +68,16 @@ object JobType {
 
 }
 
-class JobTypes(jobTypeList: List[JobType]) {
+class JobTypes(val all: List[JobType]) {
+
+  val fullList = all :+ JobTypes.JobSupervisor
 
   /**
    * Resolves a JobType by name. Compares built in JobType and given JobTypes.
    */
   def apply(name: String): Option[JobType] = {
-    (jobTypeList :+ JobTypes.JobSupervisor).find(_.name == name)
+    fullList.find(_.name == name)
   }
-
-  def all: List[JobType] = jobTypeList
 
 }
 

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatus.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatus.scala
@@ -1,16 +1,15 @@
 package de.kaufhof.hajobs
 
-import java.util.{NoSuchElementException, UUID}
+import java.util.UUID
 
+import de.kaufhof.hajobs.JobResult.JobResult
+import de.kaufhof.hajobs.JobState.JobState
 import de.kaufhof.hajobs.utils.EnumJsonSupport
-import JobResult.JobResult
-import JobState.JobState
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import play.api.libs.json.{JsValue, _}
 
 import scala.language.implicitConversions
-import scala.util.Try
 import scala.util.control.NonFatal
 
 /**
@@ -58,7 +57,7 @@ object JobType {
 
   implicit def jobTypeReads(implicit jobTypes: JobTypes): Reads[JobType] = new Reads[JobType] {
     def reads(json: JsValue): JsResult[JobType] = json match {
-      case JsString(s) => Try(jobTypes(s)).map(JsSuccess(_)).getOrElse(JsError(s"No JobType found with name '$s'"))
+      case JsString(s) => jobTypes(s).map(JsSuccess(_)).getOrElse(JsError(s"No JobType found with name '$s'"))
       case _ => JsError("String value expected")
     }
   }
@@ -69,30 +68,16 @@ object JobType {
 
 }
 
-trait JobTypes {
-
-  import JobTypes._
+class JobTypes(jobTypeList: List[JobType]) {
 
   /**
-   * Resolves a JobType by name. Compares built in JobTypes and if none matched
-   * delegates to [[byName]].
-   *
-   * Throws a NoSuchElementException if there's no JobType
-   * with the given name. In this case exception is preferred over returning an Option to be
-   * more conformant with the other JobStatus enums.
+   * Resolves a JobType by name. Compares built in JobType and given JobTypes.
    */
-  @throws[NoSuchElementException]
-  final def apply(name: String): JobType = lookup(name)
-
-  private def lookup: PartialFunction[String, JobType] = byName orElse {
-    case JobSupervisor.name => JobSupervisor
-    case unknown => throw new NoSuchElementException(s"Could not find JobType with name '$unknown'.")
+  def apply(name: String): Option[JobType] = {
+    (jobTypeList :+ JobTypes.JobSupervisor).find(_.name == name)
   }
 
-  /**
-   * Resolves a JobType by name.
-   */
-  protected def byName: PartialFunction[String, JobType]
+  def all: List[JobType] = jobTypeList
 
 }
 
@@ -100,10 +85,7 @@ object JobTypes {
 
   object JobSupervisor extends JobType("supervisor", lockType = LockTypes.JobSupervisorLock)
 
-  def apply(jobTypes: JobType*): JobTypes = new JobTypes {
-    private val jobTypesByName = jobTypes.map(jobType => jobType.name -> jobType).toMap
-    override protected def byName: PartialFunction[String, JobType] = jobTypesByName
-  }
+  def apply(jobTypes: JobType*): JobTypes = new JobTypes(jobTypes.toList)
 
 }
 

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatusRepository.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatusRepository.scala
@@ -87,7 +87,7 @@ class JobStatusRepository(session: Session,
    */
   def getLatestMetadata(readwithQuorum: Boolean = false)(implicit ec: ExecutionContext): Future[List[JobStatus]] = {
 
-    def selectStmt(jobType: JobType, withQuorum: Boolean) = {
+    def getLatest(jobType: JobType, withQuorum: Boolean) = {
       val stmt: Where = select().all().from(MetaTable).where(QueryBuilder.eq(JobTypeColumn, jobType.name))
       if (withQuorum) {
         // setConsistencyLevel returns "this", we do not need to reassign
@@ -97,7 +97,7 @@ class JobStatusRepository(session: Session,
     }
 
     val results = jobTypes.all.map { jobType =>
-      session.executeAsync(selectStmt(jobType, readwithQuorum)).map(res =>
+      session.executeAsync(getLatest(jobType, readwithQuorum)).map(res =>
         Option(res.one).flatMap(result =>
           rowToStatus(result, isMeta = true)
         ))

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatusRepository.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatusRepository.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import com.datastax.driver.core.ConsistencyLevel.LOCAL_QUORUM
 import com.datastax.driver.core.querybuilder.QueryBuilder
 import com.datastax.driver.core.querybuilder.QueryBuilder._
+import com.datastax.driver.core.querybuilder.Select.Where
 import de.kaufhof.hajobs.utils.CassandraUtils
 import CassandraUtils._
 import com.datastax.driver.core._
@@ -79,22 +80,30 @@ class JobStatusRepository(session: Session,
 
   /**
    * Finds the latest job status entries for all jobs.
+   * Every JobState is loaded with a single select statement
+   * It is recommened to use partition keys if possible and avoid
+   * IN statement in WHERE clauses, therefore we prefer to execute
+   * more than one select statement
    */
-  def getAllMetadata(readWithQuorum: Boolean = false)(implicit ec: ExecutionContext): Future[List[JobStatus]] = {
-    import scala.collection.JavaConversions._
+  def getLatestMetadata(readwithQuorum: Boolean = false)(implicit ec: ExecutionContext): Future[List[JobStatus]] = {
 
-    val selectStmt = select().all().from(MetaTable)
-
-    if (readWithQuorum) {
-      // setConsistencyLevel returns "this", we do not need to reassign
-      selectStmt.setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM)
+    def selectStmt(jobType: JobType, withQuorum: Boolean) = {
+      val stmt: Where = select().all().from(MetaTable).where(QueryBuilder.eq(JobTypeColumn, jobType.name))
+      if (withQuorum) {
+        // setConsistencyLevel returns "this", we do not need to reassign
+        stmt.setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM)
+      }
+      stmt
     }
 
-    val resultFuture: ResultSetFuture = session.executeAsync(selectStmt)
-    resultFuture.map( res =>
-      res.all().toList.flatMap( result =>
-        rowToStatus(result, isMeta = true)
-      ))
+    val results = jobTypes.all.map { jobType =>
+      session.executeAsync(selectStmt(jobType, readwithQuorum)).map(res =>
+        Option(res.one).flatMap(result =>
+          rowToStatus(result, isMeta = true)
+        ))
+
+    }
+    Future.sequence(results).map(_.flatten)
   }
 
   /**
@@ -162,19 +171,25 @@ class JobStatusRepository(session: Session,
 
   private def rowToStatus(row: Row, isMeta: Boolean): Option[JobStatus] = {
     try {
-      Some(JobStatus(
-        row.getUUID(TriggerIdColumn),
-        jobTypes(row.getString(JobTypeColumn)),
-        row.getUUID(JobIdColumn),
-        JobState.withName(row.getString(JobStateColumn)),
-        JobResult.withName(row.getString(JobResultColumn)),
-        new DateTime(row.getDate(TimestampColumn).getTime),
-        if (!isMeta) {
-          readContent(row)
-        } else {
+      val jobTypeName: String = row.getString(JobTypeColumn)
+      jobTypes(jobTypeName) match {
+        case Some(jobType) =>
+          Some(JobStatus(
+            row.getUUID(TriggerIdColumn),
+            jobType,
+            row.getUUID(JobIdColumn),
+            JobState.withName(row.getString(JobStateColumn)),
+            JobResult.withName(row.getString(JobResultColumn)),
+            new DateTime(row.getDate(TimestampColumn).getTime),
+            if (!isMeta) {
+              readContent(row)
+            } else {
+              None
+            }
+          ))
+        case None => logger.error(s"Could not find Jobtype for name: $jobTypeName")
           None
-        }
-      ))
+      }
     } catch {
       case NonFatal(e) =>
         logger.error("error mapping a JobStatus datarow to JobStatus object", e)

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobSupervisor.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobSupervisor.scala
@@ -82,7 +82,7 @@ class JobSupervisor(jobManager: => JobManager,
    * @return
    */
   private[hajobs] def retriggerJobs(): Future[Seq[JobStartStatus]] = {
-    jobStatusRepository.getAllMetadata().flatMap { allJobs =>
+    jobStatusRepository.getLatestMetadata().flatMap { allJobs =>
       val a = allJobs.groupBy(_.jobType).flatMap { case (jobType, jobStatus) =>
         triggerIdToRetrigger(jobType, jobStatus).map { triggerId =>
           logger.info(s"Retriggering job of type $jobType with triggerid $triggerId")

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobUpdater.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobUpdater.scala
@@ -25,7 +25,7 @@ class JobUpdater(lockRepository: LockRepository, jobStatusRepository: JobStatusR
       // we also need to read with quorom to ensure we get the most current
       // (and consistent) data
       locks <- lockRepository.getAll()
-      jobs <- jobStatusRepository.getAllMetadata(readWithQuorum = true)
+      jobs <- jobStatusRepository.getLatestMetadata(readwithQuorum = true)
 
       runningJobs = jobs.filter(_.jobResult == JobResult.Pending)
       deadJobs = runningJobs.filterNot(job => locks.exists(_.jobId == job.jobId))

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/Lock.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/Lock.scala
@@ -15,14 +15,14 @@ case class Lock(lockType: LockType, jobId: UUID)
  */
 case class LockType(name: String)
 
-class LockTypes(lockTypes: Seq[LockType]) {
+class LockTypes(val all: Seq[LockType]) {
+
+  val fullList = all :+ JobSupervisorLock
 
   /**
    * Resolves a LockType by name. Compares built in LockTypes and given LockTypes.
    */
-  final def apply(name: String): Option[LockType] = (lockTypes :+ JobSupervisorLock).find(_.name == name)
-
-  def all: Seq[LockType] = lockTypes
+  final def apply(name: String): Option[LockType] = fullList.find(_.name == name)
 
 }
 

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/LockRepository.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/LockRepository.scala
@@ -136,12 +136,12 @@ class LockRepository(session: Session, lockTypes: LockTypes) {
    * we do multiple select statements with given primary key
    */
   def getAll()(implicit ec: ExecutionContext): Future[Seq[Lock]] = {
-    def query(lockType: LockType) = select().all().from(Table)
+    def getLock(lockType: LockType) = select().all().from(Table)
       .where(QueryBuilder.eq(LockTypeCol, lockType.name))
       .setConsistencyLevel(LOCAL_QUORUM)
 
     val res = lockTypes.all.map { lockType =>
-      session.executeAsync(query(lockType)).map(rs =>
+      session.executeAsync(getLock(lockType)).map(rs =>
         Option(rs.one).flatMap { row =>
           val lockTypeName = row.getString(LockTypeCol)
           lockTypes(lockTypeName) match {

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/LockRepository.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/LockRepository.scala
@@ -8,12 +8,13 @@ import CassandraUtils._
 import com.datastax.driver.core._
 import com.datastax.driver.core.querybuilder.QueryBuilder._
 import com.datastax.driver.core.querybuilder.{Insert, QueryBuilder}
+import org.slf4j.LoggerFactory._
 
 import scala.collection.JavaConversions._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 /**
  * This repository manages locks for jobs syncronization in distributed environments.
@@ -28,6 +29,8 @@ import scala.util.Try
  * @param session
  */
 class LockRepository(session: Session, lockTypes: LockTypes) {
+
+  private val logger = getLogger(getClass)
 
   private val Table = "lock"
 
@@ -129,17 +132,27 @@ class LockRepository(session: Session, lockTypes: LockTypes) {
 
   /**
    * Returns a list of Locks (jobType + jobId).
+   * To avoid select * statement without key in where clause,
+   * we do multiple select statements with given primary key
    */
   def getAll()(implicit ec: ExecutionContext): Future[Seq[Lock]] = {
-    val query = select().all().from(Table).setConsistencyLevel(LOCAL_QUORUM)
-    session.executeAsync(query).map(rs =>
-      rs.all().foldLeft(Seq.empty[Lock]) { (res, row) =>
-        val lockTypeName = row.getString(LockTypeCol)
-        Try(lockTypes(lockTypeName))
-          .map(lockType => res :+ Lock(lockType, row.getUUID(LockCol)))
-          .getOrElse(res)
-      }
-    )
+    def query(lockType: LockType) = select().all().from(Table)
+      .where(QueryBuilder.eq(LockTypeCol, lockType.name))
+      .setConsistencyLevel(LOCAL_QUORUM)
+
+    val res = lockTypes.all.map { lockType =>
+      session.executeAsync(query(lockType)).map(rs =>
+        Option(rs.one).flatMap { row =>
+          val lockTypeName = row.getString(LockTypeCol)
+          lockTypes(lockTypeName) match {
+            case Some(lockType) => Some(Lock(lockType, row.getUUID(LockCol)))
+            case None => logger.error(s"Could not find matching lock type for name: $lockTypeName")
+              None
+          }
+        }
+      )
+    }
+    Future.sequence(res).map(_.flatten)
   }
 
   def clear(): Future[ResultSet] = {

--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobStatusRepositorySpec.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobStatusRepositorySpec.scala
@@ -27,7 +27,7 @@ class JobStatusRepositorySpec extends CassandraSpec {
   "job status repository" should {
 
     "get a job status by id" in {
-      assume(await(repo.getAllMetadata()) === List.empty)
+      assume(await(repo.getLatestMetadata()) === List.empty)
       // given
       val jobStatus1: JobStatus = JobStatus(anyTriggerId, type1, UUIDs.timeBased(), Finished, JobResult.Success, DateTime.now, Some(Json.toJson("muhmuh")))
       // a job status without content should also be loaded
@@ -44,12 +44,12 @@ class JobStatusRepositorySpec extends CassandraSpec {
     }
 
     "return empty list if nothing is saved in the repo" in {
-      assume(await(repo.getAllMetadata()) === List.empty)
+      assume(await(repo.getLatestMetadata()) === List.empty)
       await(repo.list(type1)) should be(Nil)
     }
 
     "list Job status if job status is saved in the repo" in {
-      assume(await(repo.getAllMetadata()) === List.empty)
+      assume(await(repo.getLatestMetadata()) === List.empty)
       // given
       val jobId1: UUID = UUIDs.timeBased()
       val jobId2: UUID = UUIDs.timeBased()
@@ -66,7 +66,7 @@ class JobStatusRepositorySpec extends CassandraSpec {
     }
 
     "return all JobStates on listAll" in {
-      assume(await(repo.getAllMetadata()) === List.empty)
+      assume(await(repo.getLatestMetadata()) === List.empty)
       val jobId1: UUID = UUIDs.timeBased()
       val jobId2: UUID = UUIDs.timeBased()
       val jobStatus1: JobStatus = JobStatus(anyTriggerId, type1, jobId1, Running, JobResult.Pending, DateTime.now, Some(Json.toJson("muhmuh")))
@@ -76,26 +76,26 @@ class JobStatusRepositorySpec extends CassandraSpec {
       await(Future.sequence(Seq(repo.save(jobStatus1), repo.save(jobStatus2))))
 
       eventually {
-        val lst = await(repo.getAllMetadata())
+        val lst = await(repo.getLatestMetadata())
         lst.size should be(2)
         lst.map(_.jobType) should contain allOf(type1, type2)
       }
     }
 
     "update meta data and insert data on update" in {
-      assume(await(repo.getAllMetadata()) === List.empty)
+      assume(await(repo.getLatestMetadata()) === List.empty)
       val jobId1: UUID = UUIDs.timeBased()
       val jobStatus1: JobStatus = JobStatus(anyTriggerId, type1, jobId1, Finished, JobResult.Failed, DateTime.now, Some(Json.toJson("muhmuh")))
 
       // when
       await(repo.save(jobStatus1))
       eventually{
-        await(repo.getAllMetadata()).find(_.jobId == jobId1).map(_.jobState).value should be (jobStatus1.jobState)
+        await(repo.getLatestMetadata()).find(_.jobId == jobId1).map(_.jobState).value should be (jobStatus1.jobState)
       }
 
       val jobStatus2 = await(repo.updateJobState(jobStatus1, Canceled))
       eventually{
-        await(repo.getAllMetadata()).find(_.jobId == jobId1).map(_.jobState).value should be (jobStatus2.jobState)
+        await(repo.getLatestMetadata()).find(_.jobId == jobId1).map(_.jobState).value should be (jobStatus2.jobState)
       }
 
       eventually {

--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobUpdaterSpec.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobUpdaterSpec.scala
@@ -19,7 +19,7 @@ class JobUpdaterSpec extends StandardSpec {
 
     "set jobStatus of dead jobs to dead" in {
       when(lockRepository.getAll()).thenReturn(Future.successful(Seq.empty))
-      when(jobStatusRepository.getAllMetadata(anyBoolean())(any())).thenReturn(Future.successful(List(job)))
+      when(jobStatusRepository.getLatestMetadata(anyBoolean())(any())).thenReturn(Future.successful(List(job)))
       when(jobStatusRepository.updateJobState(any(), any())(any())).thenReturn(Future.successful(job))
 
       val jobUpdater = new JobUpdater(lockRepository, jobStatusRepository)

--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/TestFixtures.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/TestFixtures.scala
@@ -3,12 +3,7 @@ package de.kaufhof.hajobs
 object LockType1 extends LockType("testLock1")
 object LockType2 extends LockType("testLock2")
 
-object TestLockTypes extends LockTypes {
-  override protected def byName: PartialFunction[String, LockType] = {
-    case LockType1.name => LockType1
-    case LockType2.name => LockType2
-  }
-}
+object TestLockTypes extends LockTypes(List(LockType1, LockType2))
 
 object JobType1 extends JobType("testJob1", LockType1)
 object JobType2 extends JobType("testJob2", LockType2)

--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/TestFixtures.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/TestFixtures.scala
@@ -13,9 +13,4 @@ object TestLockTypes extends LockTypes {
 object JobType1 extends JobType("testJob1", LockType1)
 object JobType2 extends JobType("testJob2", LockType2)
 
-object TestJobTypes extends JobTypes {
-  override protected def byName: PartialFunction[String, JobType] = {
-    case JobType1.name => JobType1
-    case JobType2.name => JobType2
-  }
-}
+object TestJobTypes extends JobTypes(List(JobType1, JobType2))


### PR DESCRIPTION
Datastax recommends to use partition key if possible and
avoiding IN statements in WHERE clauses. Therefore the job
status meta data should be loaded by multiple SELECT statements
with primary key and without IN.
