### PR TITLE
Bugfix in Job supervisor

### DIFF
--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobManager.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobManager.scala
@@ -164,6 +164,10 @@ class JobManager(managedJobs: => Jobs,
 
   def jobStatus(jobType: JobType, jobId: UUID): Future[Option[JobStatus]] = jobStatusRepo.get(jobType, jobId)
 
+  private[hajobs] def retriggerCounts: Map[JobType, Int] = managedJobs.map { case (jobType, job) =>
+    jobType -> job.retriggerCount
+  }
+
 }
 
 object JobManager {

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatusRepository.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatusRepository.scala
@@ -108,10 +108,10 @@ class JobStatusRepository(session: Session,
    * IN statement in WHERE clauses, therefore we prefer to execute
    * more than one select statement
    */
-  def getAllMetadata(readwithQuorum: Boolean = false)(implicit ec: ExecutionContext): Future[Map[JobType, List[JobStatus]]] = {
+  def getMetadata(readwithQuorum: Boolean = false, limitByJobType: JobType => Int)(implicit ec: ExecutionContext): Future[Map[JobType, List[JobStatus]]] = {
     def getAllMetadata(jobType: JobType): Future[(JobType, List[JobStatus])] = {
       import scala.collection.JavaConversions._
-      val selectMetadata = select().all().from(MetaTable).where(QueryBuilder.eq(JobTypeColumn, jobType.name))
+      val selectMetadata = select().all().from(MetaTable).where(QueryBuilder.eq(JobTypeColumn, jobType.name)).limit(limitByJobType(jobType))
       if (readwithQuorum) {
         // setConsistencyLevel returns "this", we do not need to reassign
         selectMetadata.setConsistencyLevel(ConsistencyLevel.LOCAL_QUORUM)

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobSupervisor.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobSupervisor.scala
@@ -82,7 +82,8 @@ class JobSupervisor(jobManager: => JobManager,
    * @return
    */
   private[hajobs] def retriggerJobs(): Future[Seq[JobStartStatus]] = {
-    jobStatusRepository.getAllMetadata().flatMap { jobStatusMap =>
+    def retriggerCount: (JobType) => Int = jobManager.retriggerCounts.getOrElse(_, 10)
+    jobStatusRepository.getMetadata(limitByJobType = retriggerCount).flatMap { jobStatusMap =>
       val a = jobStatusMap.flatMap { case (jobStatus, jobStatusList) =>
         triggerIdToRetrigger(jobType, jobStatusList).map { triggerId =>
           logger.info(s"Retriggering job of type $jobType with triggerid $triggerId")

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobSupervisor.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobSupervisor.scala
@@ -82,9 +82,9 @@ class JobSupervisor(jobManager: => JobManager,
    * @return
    */
   private[hajobs] def retriggerJobs(): Future[Seq[JobStartStatus]] = {
-    jobStatusRepository.getLatestMetadata().flatMap { allJobs =>
-      val a = allJobs.groupBy(_.jobType).flatMap { case (jobType, jobStatus) =>
-        triggerIdToRetrigger(jobType, jobStatus).map { triggerId =>
+    jobStatusRepository.getAllMetadata().flatMap { jobStatusMap =>
+      val a = jobStatusMap.flatMap { case (jobStatus, jobStatusList) =>
+        triggerIdToRetrigger(jobType, jobStatusList).map { triggerId =>
           logger.info(s"Retriggering job of type $jobType with triggerid $triggerId")
           jobManager.retriggerJob(jobType, triggerId)
         }
@@ -93,20 +93,24 @@ class JobSupervisor(jobManager: => JobManager,
     }
   }
 
-  private def triggerIdToRetrigger(jobType: JobType, jobStatus: List[JobStatus]): Option[UUID] = {
+  private def triggerIdToRetrigger(jobType: JobType, jobStatusList: List[JobStatus]): Option[UUID] = {
     val job = jobManager.getJob(jobType)
-    val latestTriggerId = jobStatus.sortBy(_.jobStatusTs.getMillis).last.triggerId
-    val jobsOfLatestTrigger = jobStatus.filter(_.triggerId == latestTriggerId)
+    val maybeLatestTriggerId = jobStatusList.sortBy(_.jobStatusTs.getMillis).lastOption.map(_.triggerId)
 
-    // we don't need to restart a job that already succeeded
-    // or thats pending, cause we don't know the reuslt of that job
-    val someJobIsRunningOrPending = jobsOfLatestTrigger.exists(js => js.jobResult == JobResult.Pending
-      || js.jobResult == JobResult.Success)
+    maybeLatestTriggerId flatMap { latestTriggerId =>
+        val jobsOfLatestTrigger = jobStatusList.filter(_.triggerId == latestTriggerId)
 
-    if (!someJobIsRunningOrPending && jobsOfLatestTrigger.size <= job.retriggerCount) {
-      Some(latestTriggerId)
-    } else {
-      None
+        // we don't need to restart a job that already succeeded
+        // or thats pending, cause we don't know the reuslt of that job
+        val someJobIsRunningOrPending = jobsOfLatestTrigger.exists(js => js.jobResult == JobResult.Pending
+          || js.jobResult == JobResult.Success)
+
+        if (!someJobIsRunningOrPending && jobsOfLatestTrigger.size <= job.retriggerCount) {
+          maybeLatestTriggerId
+        } else {
+          None
+        }
     }
+
   }
 }

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobUpdater.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobUpdater.scala
@@ -27,9 +27,9 @@ class JobUpdater(lockRepository: LockRepository, jobStatusRepository: JobStatusR
       // we also need to read with quorom to ensure we get the most current
       // (and consistent) data
       locks <- lockRepository.getAll()
-      jobs <- jobStatusRepository.getLatestMetadata(readwithQuorum = true)
+      jobs <- jobStatusRepository.getAllMetadata(readwithQuorum = true)
 
-      runningJobs = jobs.filter(_.jobResult == JobResult.Pending)
+      runningJobs = jobs.flatMap(_._2).toList.filter(_.jobResult == JobResult.Pending)
       deadJobs = runningJobs.filterNot(job => locks.exists(_.jobId == job.jobId))
       updatedJobs <- updateDeadJobState(deadJobs)
 

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobUpdater.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobUpdater.scala
@@ -27,7 +27,7 @@ class JobUpdater(lockRepository: LockRepository, jobStatusRepository: JobStatusR
       // we also need to read with quorom to ensure we get the most current
       // (and consistent) data
       locks <- lockRepository.getAll()
-      jobs <- jobStatusRepository.getAllMetadata(readwithQuorum = true)
+      jobs <- jobStatusRepository.getMetadata(readwithQuorum = true, limitByJobType = _ => 10)
 
       runningJobs = jobs.flatMap(_._2).toList.filter(_.jobResult == JobResult.Pending)
       deadJobs = runningJobs.filterNot(job => locks.exists(_.jobId == job.jobId))

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/LockRepository.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/LockRepository.scala
@@ -6,7 +6,6 @@ import com.datastax.driver.core.ConsistencyLevel.{LOCAL_QUORUM, LOCAL_SERIAL}
 import com.datastax.driver.core._
 import com.datastax.driver.core.querybuilder.QueryBuilder._
 import com.datastax.driver.core.querybuilder.{Insert, QueryBuilder}
-import de.kaufhof.hajobs.utils.CassandraUtils
 import de.kaufhof.hajobs.utils.CassandraUtils._
 import org.slf4j.LoggerFactory._
 

--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobStatusRepositorySpec.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobStatusRepositorySpec.scala
@@ -34,7 +34,7 @@ class JobStatusRepositorySpec extends CassandraSpec {
       val jobStatus2: JobStatus = JobStatus(anyTriggerId, type1, UUIDs.timeBased(), Finished, JobResult.Success, DateTime.now)
 
       // when
-      await(Future.sequence((Seq(repo.save(jobStatus1), repo.save(jobStatus2)))))
+      await(Future.sequence(Seq(repo.save(jobStatus1), repo.save(jobStatus2))))
 
       // then
       eventually {
@@ -82,6 +82,28 @@ class JobStatusRepositorySpec extends CassandraSpec {
       }
     }
 
+    "return all JobStatus Metadata on getAllMetadata" in {
+      assume(await(repo.getAllMetadata()).flatMap(_._2) === List.empty)
+      val jobId1: UUID = UUIDs.timeBased()
+      val jobId2: UUID = UUIDs.timeBased()
+      val jobId3: UUID = UUIDs.timeBased()
+      val jobId4: UUID = UUIDs.timeBased()
+      val jobStatus1: JobStatus = JobStatus(anyTriggerId, type1, jobId1, Failed, JobResult.Failed, DateTime.now, Some(Json.toJson("muhmuh1")))
+      val jobStatus2: JobStatus = JobStatus(anyTriggerId, type1, jobId2, Failed, JobResult.Failed, DateTime.now, Some(Json.toJson("muhmuh2")))
+      val jobStatus3: JobStatus = JobStatus(anyTriggerId, type2, jobId3, Failed, JobResult.Failed, DateTime.now, Some(Json.toJson("muhmuh3")))
+      val jobStatus4: JobStatus = JobStatus(anyTriggerId, type2, jobId4, Failed, JobResult.Failed, DateTime.now, Some(Json.toJson("muhmuh4")))
+
+      // when
+      await(Future.sequence(Seq(repo.save(jobStatus1), repo.save(jobStatus2), repo.save(jobStatus3), repo.save(jobStatus4))))
+
+      eventually {
+        val map = await(repo.getAllMetadata())
+        map.size should be(2)
+        map.flatMap(_._2).size should be(4)
+        map.flatMap(_._2).map(_.jobId) should contain allOf(jobId1, jobId2, jobId3, jobId4)
+      }
+    }
+
     "update meta data and insert data on update" in {
       assume(await(repo.getLatestMetadata()) === List.empty)
       val jobId1: UUID = UUIDs.timeBased()
@@ -99,7 +121,7 @@ class JobStatusRepositorySpec extends CassandraSpec {
       }
 
       eventually {
-        await(repo.getJobHistory(type1, jobId1)).map(_.jobState) should contain theSameElementsAs (Seq(Canceled, Finished))
+        await(repo.getJobHistory(type1, jobId1)).map(_.jobState) should contain theSameElementsAs Seq(Canceled, Finished)
       }
     }
   }

--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobStatusRepositorySpec.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobStatusRepositorySpec.scala
@@ -83,7 +83,7 @@ class JobStatusRepositorySpec extends CassandraSpec {
     }
 
     "return all JobStatus Metadata on getAllMetadata" in {
-      assume(await(repo.getAllMetadata()).flatMap(_._2) === List.empty)
+      assume(await(repo.getMetadata(limitByJobType = _ => 10)).flatMap(_._2) === List.empty)
       val jobId1: UUID = UUIDs.timeBased()
       val jobId2: UUID = UUIDs.timeBased()
       val jobId3: UUID = UUIDs.timeBased()
@@ -97,7 +97,7 @@ class JobStatusRepositorySpec extends CassandraSpec {
       await(Future.sequence(Seq(repo.save(jobStatus1), repo.save(jobStatus2), repo.save(jobStatus3), repo.save(jobStatus4))))
 
       eventually {
-        val map = await(repo.getAllMetadata())
+        val map = await(repo.getMetadata(limitByJobType = _ => 10))
         map.size should be(2)
         map.flatMap(_._2).size should be(4)
         map.flatMap(_._2).map(_.jobId) should contain allOf(jobId1, jobId2, jobId3, jobId4)

--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobUpdaterSpec.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobUpdaterSpec.scala
@@ -26,7 +26,7 @@ class JobUpdaterSpec extends StandardSpec {
     "set jobStatus of dead jobs to dead" in {
       when(lockRepository.getAll()).thenReturn(Future.successful(Seq.empty))
       val successful: Future[Map[JobType, List[JobStatus]]] = Future.successful(Map(JobType1 -> List(job)))
-      when(jobStatusRepository.getAllMetadata(anyBoolean())(any())).thenReturn(successful)
+      when(jobStatusRepository.getMetadata(anyBoolean(), any())(any())).thenReturn(successful)
       when(jobStatusRepository.updateJobState(any(), any())(any())).thenReturn(Future.successful(jobWithData))
       when(jobStatusRepository.get(any(), any(), anyBoolean())(any())).thenReturn(Future.successful(Some(jobWithData)))
 

--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobUpdaterSpec.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobUpdaterSpec.scala
@@ -25,7 +25,8 @@ class JobUpdaterSpec extends StandardSpec {
 
     "set jobStatus of dead jobs to dead" in {
       when(lockRepository.getAll()).thenReturn(Future.successful(Seq.empty))
-      when(jobStatusRepository.getLatestMetadata(anyBoolean())(any())).thenReturn(Future.successful(List(job)))
+      val successful: Future[Map[JobType, List[JobStatus]]] = Future.successful(Map(JobType1 -> List(job)))
+      when(jobStatusRepository.getAllMetadata(anyBoolean())(any())).thenReturn(successful)
       when(jobStatusRepository.updateJobState(any(), any())(any())).thenReturn(Future.successful(jobWithData))
       when(jobStatusRepository.get(any(), any(), anyBoolean())(any())).thenReturn(Future.successful(Some(jobWithData)))
 


### PR DESCRIPTION
retriggerJob should retrigger jobs based on their configured retrigger count

Job Supervisor should only retrigger Jobs that are not already retriggered
more often than the configured retrigger count. Therefore we need to check
all metadata of a jobType and not only the latest metadata entry.

Job Updater had the same Problem regarding finding dead jobs. We want to mark
every dead job entry as Failed/Dead and not only the latest execution of a Job.
