### PR TITLE
Addresses problem that the retriggerLimit can be zero by default

### DIFF
--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/ActorJob.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/ActorJob.scala
@@ -17,7 +17,7 @@ import scala.language.postfixOps
 class ActorJob(jobType: JobType,
                props: JobContext => Props,
                system: ActorSystem,
-               retriggerCount: Int = 0,
+               retriggerCount: Int = 1,
                cronExpression: Option[String] = None,
                lockTimeout: FiniteDuration = 60 seconds)
   extends Job(jobType, retriggerCount, cronExpression, lockTimeout) {

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/Job.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/Job.scala
@@ -33,7 +33,7 @@ case class JobContext(jobType: JobType, jobId: UUID, triggerId: UUID)
  * For actor jobs you can just use the `ActorJob`.
  */
 abstract class Job(val jobType: JobType,
-                   val retriggerCount: Int,
+                   val retriggerCount: Int = 1,
                    val cronExpression: Option[String] = None,
                    val lockTimeout: FiniteDuration = 60 seconds) {
 

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobSupervisor.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobSupervisor.scala
@@ -82,7 +82,7 @@ class JobSupervisor(jobManager: => JobManager,
    * @return
    */
   private[hajobs] def retriggerJobs(): Future[Seq[JobStartStatus]] = {
-    def retriggerCount: (JobType) => Int = jobManager.retriggerCounts.getOrElse(_, 10)
+    def retriggerCount: JobType => Int = jobType => jobManager.retriggerCounts.getOrElse(jobType, 10)
     jobStatusRepository.getMetadata(limitByJobType = retriggerCount).flatMap { jobStatusMap =>
       val a = jobStatusMap.flatMap { case (jobStatus, jobStatusList) =>
         triggerIdToRetrigger(jobType, jobStatusList).map { triggerId =>


### PR DESCRIPTION
, whereas C\* expects it to be > 0.

This is not a real fix, but avoids that default values cause an IllegalArgumentException in the datastax driver. I also did not check why a retriggerCount is used for the limit in the query.
