### PR TITLE
Bugfix in JobSupervisor

### DIFF
--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatusRepository.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobStatusRepository.scala
@@ -134,9 +134,7 @@ class JobStatusRepository(session: Session,
       }
 
       for {
-        selectMetadata <- Future {
-          selectStmt
-        }
+        selectMetadata <- Future(selectStmt)
         metadata <- session.executeAsync(selectMetadata).map(res => {
           val jobStatusList: List[JobStatus] = res.all.toList.flatMap(row => rowToStatus(row, isMeta = true))
           jobType -> jobStatusList

--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobSupervisorSpec.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobSupervisorSpec.scala
@@ -105,8 +105,9 @@ class JobSupervisorSpec extends StandardSpec {
     }
 
     "retrigger a job if no job of the last trigger was successful and retrigger size is not reached" in {
-      val job1 = JobStatus(UUIDs.timeBased(), JobTypes.JobSupervisor, UUIDs.timeBased(), JobState.Canceled, JobResult.Failed, DateTime.now.minusMillis(1))
-      val successful: Future[Map[JobType, List[JobStatus]]] = Future.successful(Map(JobTypes.JobSupervisor -> List(job1)))
+      val jobTypeDummy: JobType = JobType("dummy", LockType("dummy"))
+      val job1 = JobStatus(UUIDs.timeBased(), jobTypeDummy, UUIDs.timeBased(), JobState.Canceled, JobResult.Failed, DateTime.now.minusMillis(1))
+      val successful: Future[Map[JobType, List[JobStatus]]] = Future.successful(Map(jobTypeDummy -> List(job1)))
       when(jobStatusRepository.getMetadata(anyBoolean(), any())(any())).thenReturn(successful)
       when(lockRepository.getAll()(any())).thenReturn(Future.successful(Seq.empty))
       val sut = new JobSupervisor(jobManager, lockRepository, jobStatusRepository)
@@ -116,11 +117,12 @@ class JobSupervisorSpec extends StandardSpec {
     }
 
     "do nothing if no job of the last trigger was successful and retrigger size is reached" in {
-      val job1 = JobStatus(UUIDs.timeBased(), JobTypes.JobSupervisor, UUIDs.timeBased(), JobState.Failed, JobResult.Failed, DateTime.now.minusMillis(0))
+      val jobTypeDummy: JobType = JobType("dummy", LockType("dummy"))
+      val job1 = JobStatus(UUIDs.timeBased(), jobTypeDummy, UUIDs.timeBased(), JobState.Failed, JobResult.Failed, DateTime.now.minusMillis(0))
       val job2 = job1.copy(jobStatusTs = DateTime.now.minusMillis(1), jobId = UUIDs.random())
       val job3 = job1.copy(jobStatusTs = DateTime.now.minusMillis(2), jobId = UUIDs.random())
       val job4 = job1.copy(jobStatusTs = DateTime.now.minusMillis(2), jobId = UUIDs.random())
-      val successful: Future[Map[JobType, List[JobStatus]]] = Future.successful(Map(JobTypes.JobSupervisor -> List(job1, job2, job3, job4)))
+      val successful: Future[Map[JobType, List[JobStatus]]] = Future.successful(Map(jobTypeDummy -> List(job1, job2, job3, job4)))
       when(jobStatusRepository.getMetadata(anyBoolean(), any())(any())).thenReturn(successful)
       when(lockRepository.getAll()(any())).thenReturn(Future.successful(Seq.empty))
       val sut = new JobSupervisor(jobManager, lockRepository, jobStatusRepository)


### PR DESCRIPTION
The JobSupervisor should supervise jobs and in case of failure
retrigger the them. The retrigger method had a bug so all
jobs were retriggered with the jobtype of the job supervisor.
