### PR TITLE
add starttime and duration to jobstatus json output

### DIFF
--- a/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobStatusSpec.scala
+++ b/ha-jobs-core/src/test/scala/de/kaufhof/hajobs/JobStatusSpec.scala
@@ -1,12 +1,14 @@
 package de.kaufhof.hajobs
 
+import java.util.UUID
 import java.util.UUID._
 
+import com.datastax.driver.core.utils.UUIDs
 import de.kaufhof.hajobs.JobResult._
 import de.kaufhof.hajobs.JobState._
 import de.kaufhof.hajobs.testutils.StandardSpec
-import org.joda.time.DateTime
-import org.joda.time.format.ISODateTimeFormat
+import org.joda.time.format.{ISODateTimeFormat, PeriodFormat}
+import org.joda.time.{DateTime, Period}
 import play.api.libs.json._
 
 class JobStatusSpec extends StandardSpec {
@@ -16,14 +18,31 @@ class JobStatusSpec extends StandardSpec {
   "JobStatus JsonFormat" should {
 
     val now = DateTime.now
-    val jobStatus: JobStatus = JobStatus(randomUUID(), JobType1, randomUUID(), Finished, Success, now, Some(Json.toJson("muhmuh")))
+    val startTime: Long = now.minusMinutes(10).getMillis
+    val startTimeUUID: UUID = UUIDs.startOf(startTime)
+    val jobStatus: JobStatus = JobStatus(randomUUID(), JobType1, startTimeUUID, Finished, Success, now, Some(Json.toJson("muhmuh")))
     val json = JobStatus.jobStatusWrites.writes(jobStatus)
 
     "render the timestamp in a readable form" in {
-      (json \ "jobStatusTs").as[String] should be (now.toString(ISODateTimeFormat.dateTime()))
+      (json \ "jobStatusTs").as[String] should be(now.toString(ISODateTimeFormat.dateTime()))
 
       // verify that everything else is fine
-      JobStatus.jobStatusReads.reads(json).get should be (jobStatus)
+      JobStatus.jobStatusReads.reads(json).get should be(jobStatus)
+    }
+
+    "render the duration in a readable form" in {
+      (json \ "duration").as[String] should be(new Period(0, 10, 0, 0).toString(PeriodFormat.wordBased()))
+
+      // verify that everything else is fine
+      JobStatus.jobStatusReads.reads(json).get should be(jobStatus)
+    }
+
+    "render the startTime in a readable form" in {
+      val readableStartTime: String = new DateTime(startTime).toString(ISODateTimeFormat.dateTime())
+      (json \ "startTime").as[String] should be(readableStartTime)
+
+      // verify that everything else is fine
+      JobStatus.jobStatusReads.reads(json).get should be(jobStatus)
     }
 
     "read the timestamp in legacy form (with just the unix timestamp)" in {
@@ -35,10 +54,10 @@ class JobStatusSpec extends StandardSpec {
         }
       )
       val legacyJson = json.transform(jsonTransformer).get
-      (legacyJson \ "jobStatusTs").as[Long] should be (now.getMillis)
+      (legacyJson \ "jobStatusTs").as[Long] should be(now.getMillis)
 
       // verify that the legacy json can be read
-      JobStatus.jobStatusReads.reads(legacyJson).get should be (jobStatus)
+      JobStatus.jobStatusReads.reads(legacyJson).get should be(jobStatus)
     }
   }
 


### PR DESCRIPTION
If jobId represents the start time of the job as timebased uuid
the jobstatus json should show the human readable starttime
and job duration.