### PR TITLE
Fix invalid cron expressions breaking haJobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea/
+*.iml

--- a/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobManager.scala
+++ b/ha-jobs-core/src/main/scala/de/kaufhof/hajobs/JobManager.scala
@@ -1,6 +1,5 @@
 package de.kaufhof.hajobs
 
-import java.lang.RuntimeException
 import java.util.{TimeZone, UUID}
 
 import akka.pattern.ask


### PR DESCRIPTION
If an invalid cron expression is defined the server will not gracefully handle that case. This is a bit inconsistent to having no cron entry at all, which will just ignore the entry.

This PR makes the behaviour more consistent and prevents the server from partially failing when an invalid crontab entry is defined.